### PR TITLE
Fix tests for multi-tenant controllers

### DIFF
--- a/tests/mocks/mockUtils.js
+++ b/tests/mocks/mockUtils.js
@@ -3,12 +3,24 @@
 /**
  * Creates a mock request object for testing controllers
  */
-const mockRequest = (body = {}, user = { id: '5f7e3c6a8ea7c8362a5c8b1b' }, params = {}, query = {}) => {
+// The controllers now expect a `db` property on the request object in order to
+// obtain tenant specific models.  Most of the unit tests were written before
+// multi tenancy was introduced so they don't provide this property.  To keep
+// them working we include a dummy `db` object by default and also allow it to
+// be overridden when needed.
+const mockRequest = (
+  body = {},
+  user = { id: '5f7e3c6a8ea7c8362a5c8b1b' },
+  params = {},
+  query = {},
+  db = {}
+) => {
   return {
     body,
     user,
     params,
-    query
+    query,
+    db
   };
 };
 

--- a/tests/unit/controllers/authController.test.js
+++ b/tests/unit/controllers/authController.test.js
@@ -23,6 +23,8 @@ describe('Auth Controller', () => {
     jest.clearAllMocks();
     res = mockResponse();
     req = mockRequest();
+    // Controllers obtain models from req.db, so return the mocked model
+    User.getModel.mockReturnValue(User);
     userData = {
         name: 'Existing User',
         email: 'existing@example.com',

--- a/tests/unit/controllers/operationalExpenseController.test.js
+++ b/tests/unit/controllers/operationalExpenseController.test.js
@@ -21,6 +21,7 @@ describe('Operational Expense Controller', () => {
     jest.clearAllMocks();
     res = mockResponse();
     req = mockRequest();
+    OperationalExpense.getModel.mockReturnValue(OperationalExpense);
   });
 
   afterEach(() => {

--- a/tests/unit/controllers/paymentMethodController.test.js
+++ b/tests/unit/controllers/paymentMethodController.test.js
@@ -22,6 +22,7 @@ describe('Payment Method Controller', () => {
     jest.clearAllMocks();
     res = mockResponse();
     req = mockRequest();
+    PaymentMethod.getModel.mockReturnValue(PaymentMethod);
     jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 

--- a/tests/unit/controllers/posSessionController.test.js
+++ b/tests/unit/controllers/posSessionController.test.js
@@ -29,6 +29,8 @@ describe('POS Session Controller', () => {
     res = mockResponse();
     jest.spyOn(console, 'error').mockImplementation(() => {});
     req = mockRequest();
+    PosSession.getModel.mockReturnValue(PosSession);
+    Sale.getModel.mockReturnValue(Sale);
   });
 
   afterEach(() => {

--- a/tests/unit/controllers/productController.test.js
+++ b/tests/unit/controllers/productController.test.js
@@ -25,6 +25,7 @@ describe('Product Controller', () => {
     jest.clearAllMocks();
     res = mockResponse();
     req = mockRequest();
+    Product.getModel.mockReturnValue(Product);
   });
 
   afterEach(() => {

--- a/tests/unit/controllers/purchaseController.test.js
+++ b/tests/unit/controllers/purchaseController.test.js
@@ -25,6 +25,8 @@ describe('Purchase Controller', () => {
     jest.clearAllMocks();
     res = mockResponse();
     req = mockRequest();
+    Purchase.getModel.mockReturnValue(Purchase);
+    Product.getModel.mockReturnValue(Product);
   });
 
   afterEach(() => {

--- a/tests/unit/controllers/receiptController.test.js
+++ b/tests/unit/controllers/receiptController.test.js
@@ -20,6 +20,8 @@ describe('Receipt Controller', () => {
     jest.clearAllMocks();
     res = mockResponse();
     req = mockRequest();
+    Receipt.getModel.mockReturnValue(Receipt);
+    Sale.getModel.mockReturnValue(Sale);
   });
 
   afterEach(() => {

--- a/tests/unit/controllers/saleController.test.js
+++ b/tests/unit/controllers/saleController.test.js
@@ -31,6 +31,8 @@ describe('Sale Controller', () => {
     jest.clearAllMocks();
     res = mockResponse();
     req = mockRequest();
+    Sale.getModel.mockReturnValue(Sale);
+    Product.getModel.mockReturnValue(Product);
   });
 
   afterEach(() => {
@@ -155,6 +157,7 @@ describe('Sale Controller', () => {
         changeAmount: 20
       }));
       expect(addSaleToSession).toHaveBeenCalledWith(
+        req.db,
         saleId, // Check with the ObjectId
         mockUser._id.toString()
       );

--- a/tests/unit/controllers/statsController.test.js
+++ b/tests/unit/controllers/statsController.test.js
@@ -36,6 +36,9 @@ describe('Stats Controller', () => {
     jest.clearAllMocks();
     res = mockResponse();
     req = mockRequest();
+    Sale.getModel.mockReturnValue(Sale);
+    Product.getModel.mockReturnValue(Product);
+    PosSession.getModel.mockReturnValue(PosSession);
   });
 
   afterEach(() => {

--- a/tests/unit/controllers/userController.test.js
+++ b/tests/unit/controllers/userController.test.js
@@ -16,6 +16,7 @@ describe('User Controller', () => {
     jest.clearAllMocks();
     res = mockResponse();
     req = mockRequest();
+    User.getModel.mockReturnValue(User);
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- add default `db` object to `mockRequest`
- ensure mocked models are returned from `getModel`
- update `addSaleToSession` call expectation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9cf9e2c4832ab7406d7e8207cadc