### PR TITLE
Add baseUser mock for userFactory

### DIFF
--- a/tests/mocks/userFactory.js
+++ b/tests/mocks/userFactory.js
@@ -1,11 +1,13 @@
 const { baseUser } = require('./userMock');
 
-module.exports = {
-  makeSavedUser: ({ isFirst }) => ({
+function makeSavedUser({ isFirst }) {
+  return {
     ...baseUser,
     _id: '507f191e810c19729de860ea',
     role: isFirst ? 'admin' : 'user',
     approved: isFirst,
     password: 'hashedPassword'
-  })
-};
+  };
+}
+
+module.exports = { makeSavedUser };

--- a/tests/mocks/userMock.js
+++ b/tests/mocks/userMock.js
@@ -5,6 +5,12 @@ const mongoose = require('mongoose');
 const validUserId = new mongoose.Types.ObjectId();
 const validAdminId = new mongoose.Types.ObjectId();
 
+// Base user data used by factories
+const baseUser = {
+  name: 'Existing User',
+  email: 'existing@example.com'
+};
+
 // Mock data for regular user
 const mockUser = {
   _id: validUserId,
@@ -73,6 +79,7 @@ const mockUsersList = [
 ];
 
 module.exports = {
+  baseUser,
   mockUser,
   mockAdmin,
   mockUnapprovedUser,


### PR DESCRIPTION
## Summary
- add `baseUser` helper in userMock and export it
- refactor userFactory to import the new mock
- keep unit tests working with makeSavedUser

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684dee232acc832ab26a20ab61ce1021