### PR TITLE
Centralize jest setup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@
 module.exports = {
   testEnvironment: 'node',
   testMatch: ['**/tests/**/*.test.js'],
+  setupFilesAfterEnv: ['<rootDir>/tests/setupTests.js'],
   collectCoverage: true,
   coverageDirectory: 'coverage',
   coveragePathIgnorePatterns: ['/node_modules/', '/tests/'],

--- a/tests/setupTests.js
+++ b/tests/setupTests.js
@@ -1,0 +1,14 @@
+const { mockRequest, mockResponse } = require('./mocks/mockUtils');
+
+global.mockRequest = mockRequest;
+global.mockResponse = mockResponse;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.req = mockRequest();
+  global.res = mockResponse();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});

--- a/tests/unit/controllers/authController.test.js
+++ b/tests/unit/controllers/authController.test.js
@@ -4,7 +4,7 @@ const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const authController = require('../../../controllers/authController');
 const User = require('../../../models/User');
-const { mockRequest, mockResponse } = require('../../mocks/mockUtils');
+
 const { mockUser, mockUnapprovedUser } = require('../../mocks/userMock');
 const { makeSavedUser } = require('../../mocks/userFactory');
 const { mockRegister } = require('../../utils/userControllerHelpers');
@@ -17,22 +17,15 @@ jest.mock('bcryptjs');
 jest.mock('jsonwebtoken');
 
 describe('Auth Controller', () => {
-  let req, res, userData;
+  let userData;
 
   beforeEach(() => {
-    jest.clearAllMocks();
-    res = mockResponse();
-    req = mockRequest();
     userData = {
         name: 'Existing User',
         email: 'existing@example.com',
         password: 'password123',
         role: 'user'
       };
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
   });
 
   describe('register', () => {

--- a/tests/unit/controllers/operationalExpenseController.test.js
+++ b/tests/unit/controllers/operationalExpenseController.test.js
@@ -3,7 +3,6 @@ const mongoose = require('mongoose');
 const { MESSAGES } = require('../../../config/messages');
 const operationalExpenseController = require('../../../controllers/operationalExpenseController');
 const OperationalExpense = require('../../../models/OperationalExpense');
-const { mockRequest, mockResponse } = require('../../mocks/mockUtils');
 const { 
   mockOperationalExpense, 
   mockOperationalExpense2, 
@@ -15,17 +14,6 @@ const { mockUser } = require('../../mocks/userMock');
 jest.mock('../../../models/OperationalExpense');
 
 describe('Operational Expense Controller', () => {
-  let req, res;
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    res = mockResponse();
-    req = mockRequest();
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
 
   describe('getOperationalExpenses', () => {
     test('should get operational expenses with pagination and search', async () => {

--- a/tests/unit/controllers/paymentMethodController.test.js
+++ b/tests/unit/controllers/paymentMethodController.test.js
@@ -2,7 +2,6 @@
 const mongoose = require('mongoose');
 const paymentMethodController = require('../../../controllers/paymentMethodController');
 const PaymentMethod = require('../../../models/PaymentMethod');
-const { mockRequest, mockResponse } = require('../../mocks/mockUtils');
 const { 
   mockCashPaymentMethod, 
   mockCardPaymentMethod, 
@@ -16,17 +15,8 @@ const { MESSAGES } = require('../../../config/messages');
 jest.mock('../../../models/PaymentMethod');
 
 describe('Payment Method Controller', () => {
-  let req, res;
-
   beforeEach(() => {
-    jest.clearAllMocks();
-    res = mockResponse();
-    req = mockRequest();
     jest.spyOn(console, 'error').mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
   });
 
   describe('getPaymentMethods', () => {

--- a/tests/unit/controllers/posSessionController.test.js
+++ b/tests/unit/controllers/posSessionController.test.js
@@ -4,7 +4,6 @@ const posSessionController = require('../../../controllers/posSessionController'
 const PosSession = require('../../../models/PosSession');
 const { MESSAGES } = require('../../../config/messages');
 const Sale = require('../../../models/Sale');
-const { mockRequest, mockResponse } = require('../../mocks/mockUtils');
 const { 
   mockPosSession, 
   mockClosedPosSession, 
@@ -22,17 +21,8 @@ jest.mock('../../../models/PosSession');
 jest.mock('../../../models/Sale');
 
 describe('POS Session Controller', () => {
-  let req, res;
-
   beforeEach(() => {
-    jest.clearAllMocks();
-    res = mockResponse();
     jest.spyOn(console, 'error').mockImplementation(() => {});
-    req = mockRequest();
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
   });
 
   const setupMockFindOne = (returnValue) => {

--- a/tests/unit/controllers/productController.test.js
+++ b/tests/unit/controllers/productController.test.js
@@ -5,7 +5,6 @@ const path = require('path');
 const { MESSAGES } = require('../../../config/messages');
 const productController = require('../../../controllers/productController');
 const Product = require('../../../models/Product');
-const { mockRequest, mockResponse } = require('../../mocks/mockUtils');
 const { 
   mockProduct, 
   mockProductWithVariants, 
@@ -19,17 +18,6 @@ jest.mock('fs');
 jest.mock('path');
 
 describe('Product Controller', () => {
-  let req, res;
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    res = mockResponse();
-    req = mockRequest();
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
 
   describe('createProduct', () => {
     test('should create a product successfully with JSON data', async () => {

--- a/tests/unit/controllers/purchaseController.test.js
+++ b/tests/unit/controllers/purchaseController.test.js
@@ -4,7 +4,6 @@ const purchaseController = require('../../../controllers/purchaseController');
 const Purchase = require('../../../models/Purchase');
 const Product = require('../../../models/Product');
 const { MESSAGES } = require('../../../config/messages');
-const { mockRequest, mockResponse } = require('../../mocks/mockUtils');
 const { 
   mockPurchase, 
   mockPurchaseWithPopulatedProducts, 
@@ -19,17 +18,6 @@ jest.mock('../../../models/Purchase');
 jest.mock('../../../models/Product');
 
 describe('Purchase Controller', () => {
-  let req, res;
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    res = mockResponse();
-    req = mockRequest();
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
 
   describe('getPurchases', () => {
     test('should get purchases with pagination and search', async () => {

--- a/tests/unit/controllers/receiptController.test.js
+++ b/tests/unit/controllers/receiptController.test.js
@@ -4,7 +4,6 @@ const receiptController = require('../../../controllers/receiptController');
 const Receipt = require('../../../models/Receipt');
 const Sale = require('../../../models/Sale');
 const generateReceipt = require('../../../utils/receiptGenerator');
-const { mockRequest, mockResponse } = require('../../mocks/mockUtils');
 const { mockReceipt, mockReceiptWithPopulatedSale } = require('../../mocks/receiptMock');
 const { mockCashSale } = require('../../mocks/saleMock');
 
@@ -14,17 +13,6 @@ jest.mock('../../../models/Sale');
 jest.mock('../../../utils/receiptGenerator');
 
 describe('Receipt Controller', () => {
-  let req, res;
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    res = mockResponse();
-    req = mockRequest();
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
 
   describe('getReceipt', () => {
     test('should return an existing receipt if found', async () => {

--- a/tests/unit/controllers/saleController.test.js
+++ b/tests/unit/controllers/saleController.test.js
@@ -6,7 +6,6 @@ const Product = require('../../../models/Product');
 const PosSession = require('../../../models/PosSession');
 const { MESSAGES } = require('../../../config/messages');
 // Note: posSessionController import might be removed or changed below based on new mocking strategy
-const { mockRequest, mockResponse } = require('../../mocks/mockUtils');
 const { 
   mockCashSale, 
   mockCardSale, 
@@ -27,19 +26,6 @@ jest.mock('../../../controllers/posSessionController', () => ({
 const { addSaleToSession } = require('../../../controllers/posSessionController'); // Import the mock
 
 describe('Sale Controller', () => {
-  let req, res;
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    res = mockResponse();
-    req = mockRequest();
-    // THIS NEEDS TO BE ADDED AS A MOCK IN THE MOCKS FOLDER
-    //PosSession.findOne = jest.fn().mockResolvedValue(null);
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
 
   describe('createSale', () => {
     test('should create a sale successfully with cash payment', async () => {

--- a/tests/unit/controllers/statsController.test.js
+++ b/tests/unit/controllers/statsController.test.js
@@ -5,7 +5,6 @@ const Sale = require('../../../models/Sale');
 const Product = require('../../../models/Product');
 const PosSession = require('../../../models/PosSession');
 const OperationalExpense = require('../../../models/OperationalExpense');
-const { mockRequest, mockResponse } = require('../../mocks/mockUtils');
 const { MESSAGES } = require('../../../config/messages');
 const { 
   mockCashSale, 
@@ -32,18 +31,9 @@ jest.mock('../../../models/PosSession');
 jest.mock('../../../models/OperationalExpense');
 
 describe('Stats Controller', () => {
-  let req, res;
-
   beforeEach(() => {
-    jest.clearAllMocks();
-    res = mockResponse();
-    req = mockRequest();
     // THIS NEEDS TO BE ADDED AS A MOCK IN THE MOCKS FOLDER
     OperationalExpense.find = jest.fn().mockResolvedValue([]);
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
   });
 
   describe('getSalesStats', () => {

--- a/tests/unit/controllers/userController.test.js
+++ b/tests/unit/controllers/userController.test.js
@@ -3,24 +3,12 @@ const mongoose = require('mongoose');
 const { MESSAGES } = require('../../../config/messages');
 const userController = require('../../../controllers/userController');
 const User = require('../../../models/User');
-const { mockRequest, mockResponse } = require('../../mocks/mockUtils');
 const { mockUser, mockAdmin, mockUnapprovedUser, mockUsersList } = require('../../mocks/userMock');
 
 // Mock the mongoose models
 jest.mock('../../../models/User');
 
 describe('User Controller', () => {
-  let req, res;
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    res = mockResponse();
-    req = mockRequest();
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
 
   describe('getUsers', () => {
     test('should get all users successfully', async () => {


### PR DESCRIPTION
## Summary
- add reusable setup file for jest
- register setup file in `jest.config.js`
- remove duplicated mock initialization from controller tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684df19b6f5c832abd34cd6197bf3850