### PR TITLE
Add reusable mongoose mocks and clean up tests

### DIFF
--- a/tests/mocks/mockUtils.js
+++ b/tests/mocks/mockUtils.js
@@ -62,8 +62,46 @@ const setupMockModel = (model, mockData) => {
   return model;
 };
 
+// Create a generic query chain mock used by other helpers
+const createQueryMock = (returnValue) => ({
+  populate: jest.fn().mockReturnThis(),
+  sort: jest.fn().mockResolvedValue(returnValue),
+  select: jest.fn().mockResolvedValue(returnValue),
+  skip: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  then: (resolve, reject) =>
+    Promise.resolve(returnValue).then(resolve, reject),
+  exec: jest.fn().mockResolvedValue(returnValue)
+});
+
+// Mock Model.find to resolve with provided data using chained query methods
+const mockFind = (model, data) => {
+  model.find = jest.fn().mockReturnValue(createQueryMock(data));
+};
+
+// Mock Model.findById returning a chainable query
+const mockFindById = (model, data) => {
+  model.findById = jest.fn().mockReturnValue(createQueryMock(data));
+};
+
+// Mock countDocuments returning provided count
+const mockCountDocuments = (model, count) => {
+  model.countDocuments = jest.fn().mockResolvedValue(count);
+};
+
+// Mock constructor so that calling new Model().save resolves to data
+const mockSave = (model, data) => {
+  const instance = { save: jest.fn().mockResolvedValue(data) };
+  model.mockImplementation(() => instance);
+  return instance;
+};
+
 module.exports = {
   mockRequest,
   mockResponse,
-  setupMockModel
+  setupMockModel,
+  mockFind,
+  mockFindById,
+  mockCountDocuments,
+  mockSave
 };

--- a/tests/unit/controllers/authController.test.js
+++ b/tests/unit/controllers/authController.test.js
@@ -1,9 +1,17 @@
 // Imports
+// Tests use helper mocks defined in tests/mocks/mockUtils
 const mongoose = require('mongoose');
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const authController = require('../../../controllers/authController');
 const User = require('../../../models/User');
+// Helper utilities to mock Mongoose methods
+const {
+  mockFind,
+  mockFindById,
+  mockCountDocuments,
+  mockSave
+} = require('../../mocks/mockUtils');
 
 const { mockUser, mockUnapprovedUser } = require('../../mocks/userMock');
 const { makeSavedUser } = require('../../mocks/userFactory');

--- a/tests/unit/controllers/operationalExpenseController.test.js
+++ b/tests/unit/controllers/operationalExpenseController.test.js
@@ -1,8 +1,15 @@
 // Imports
+// Helper mocks from tests/mocks/mockUtils are used
 const mongoose = require('mongoose');
 const { MESSAGES } = require('../../../config/messages');
 const operationalExpenseController = require('../../../controllers/operationalExpenseController');
 const OperationalExpense = require('../../../models/OperationalExpense');
+const {
+  mockFind,
+  mockFindById,
+  mockCountDocuments,
+  mockSave
+} = require('../../mocks/mockUtils');
 const { 
   mockOperationalExpense, 
   mockOperationalExpense2, 
@@ -23,16 +30,8 @@ describe('Operational Expense Controller', () => {
       const search = 'rent';
       req = mockRequest({}, {}, {}, { page, limit, search });
 
-      // Mock OperationalExpense.countDocuments to return count
-      OperationalExpense.countDocuments = jest.fn().mockResolvedValue(3);
-
-      // Mock OperationalExpense.find with chained methods
-      OperationalExpense.find = jest.fn().mockReturnValue({
-        populate: jest.fn().mockReturnThis(),
-        skip: jest.fn().mockReturnThis(),
-        limit: jest.fn().mockReturnThis(),
-        sort: jest.fn().mockResolvedValue(mockOperationalExpensesList)
-      });
+      mockCountDocuments(OperationalExpense, 3);
+      mockFind(OperationalExpense, mockOperationalExpensesList);
 
       // Execute the controller
       await operationalExpenseController.getOperationalExpenses(req, res);
@@ -67,16 +66,8 @@ describe('Operational Expense Controller', () => {
       const limit = 10;
       req = mockRequest({}, {}, {}, { page, limit });
 
-      // Mock OperationalExpense.countDocuments to return count
-      OperationalExpense.countDocuments = jest.fn().mockResolvedValue(3);
-
-      // Mock OperationalExpense.find with chained methods
-      OperationalExpense.find = jest.fn().mockReturnValue({
-        populate: jest.fn().mockReturnThis(),
-        skip: jest.fn().mockReturnThis(),
-        limit: jest.fn().mockReturnThis(),
-        sort: jest.fn().mockResolvedValue(mockOperationalExpensesList)
-      });
+      mockCountDocuments(OperationalExpense, 3);
+      mockFind(OperationalExpense, mockOperationalExpensesList);
 
       // Execute the controller
       await operationalExpenseController.getOperationalExpenses(req, res);
@@ -116,10 +107,7 @@ describe('Operational Expense Controller', () => {
       // Mock request with expense ID
       req = mockRequest({}, {}, { id: mockOperationalExpense._id.toString() });
 
-      // Mock OperationalExpense.findById with chained populate
-      OperationalExpense.findById = jest.fn().mockReturnValue({
-        populate: jest.fn().mockResolvedValue(mockOperationalExpense)
-      });
+      mockFindById(OperationalExpense, mockOperationalExpense);
 
       // Execute the controller
       await operationalExpenseController.getOperationalExpenseById(req, res);
@@ -133,10 +121,7 @@ describe('Operational Expense Controller', () => {
       // Mock request with non-existent expense ID
       req = mockRequest({}, {}, { id: 'nonexistent-id' });
 
-      // Mock OperationalExpense.findById to return null
-      OperationalExpense.findById = jest.fn().mockReturnValue({
-        populate: jest.fn().mockResolvedValue(null)
-      });
+      mockFindById(OperationalExpense, null);
 
       // Execute the controller
       await operationalExpenseController.getOperationalExpenseById(req, res);

--- a/tests/unit/controllers/paymentMethodController.test.js
+++ b/tests/unit/controllers/paymentMethodController.test.js
@@ -1,7 +1,14 @@
 // Imports
+// Mongoose mock helpers reside in tests/mocks/mockUtils
 const mongoose = require('mongoose');
 const paymentMethodController = require('../../../controllers/paymentMethodController');
 const PaymentMethod = require('../../../models/PaymentMethod');
+const {
+  mockFind,
+  mockFindById,
+  mockCountDocuments,
+  mockSave
+} = require('../../mocks/mockUtils');
 const { 
   mockCashPaymentMethod, 
   mockCardPaymentMethod, 
@@ -21,10 +28,7 @@ describe('Payment Method Controller', () => {
 
   describe('getPaymentMethods', () => {
     test('should get all payment methods successfully', async () => {
-      // Mock PaymentMethod.find to return payment methods
-      PaymentMethod.find = jest.fn().mockReturnValue({
-        sort: jest.fn().mockResolvedValue(mockPaymentMethodsList)
-      });
+      mockFind(PaymentMethod, mockPaymentMethodsList);
 
       // Execute the controller
       await paymentMethodController.getPaymentMethods(req, res);
@@ -55,10 +59,7 @@ describe('Payment Method Controller', () => {
 
   describe('getActivePaymentMethods', () => {
     test('should get active payment methods successfully', async () => {
-      // Mock PaymentMethod.find to return active payment methods
-      PaymentMethod.find = jest.fn().mockReturnValue({
-        sort: jest.fn().mockResolvedValue(mockActivePaymentMethodsList)
-      });
+      mockFind(PaymentMethod, mockActivePaymentMethodsList);
 
       // Execute the controller
       await paymentMethodController.getActivePaymentMethods(req, res);
@@ -92,8 +93,7 @@ describe('Payment Method Controller', () => {
       // Mock request with payment method ID
       req = mockRequest({}, {}, { id: mockCashPaymentMethod._id.toString() });
 
-      // Mock PaymentMethod.findById to return a payment method
-      PaymentMethod.findById = jest.fn().mockResolvedValue(mockCashPaymentMethod);
+      mockFindById(PaymentMethod, mockCashPaymentMethod);
 
       // Execute the controller
       await paymentMethodController.getPaymentMethodById(req, res);
@@ -107,8 +107,7 @@ describe('Payment Method Controller', () => {
       // Mock request with non-existent payment method ID
       req = mockRequest({}, {}, { id: 'nonexistent-id' });
 
-      // Mock PaymentMethod.findById to return null
-      PaymentMethod.findById = jest.fn().mockResolvedValue(null);
+      mockFindById(PaymentMethod, null);
 
       // Execute the controller
       await paymentMethodController.getPaymentMethodById(req, res);

--- a/tests/unit/controllers/productController.test.js
+++ b/tests/unit/controllers/productController.test.js
@@ -1,10 +1,17 @@
 // Imports
+// Mongoose mocks provided by tests/mocks/mockUtils
 const mongoose = require('mongoose');
 const fs = require('fs');
 const path = require('path');
 const { MESSAGES } = require('../../../config/messages');
 const productController = require('../../../controllers/productController');
 const Product = require('../../../models/Product');
+const {
+  mockFind,
+  mockFindById,
+  mockCountDocuments,
+  mockSave
+} = require('../../mocks/mockUtils');
 const { 
   mockProduct, 
   mockProductWithVariants, 
@@ -245,15 +252,9 @@ describe('Product Controller', () => {
       const search = 'test';
       req = mockRequest({}, {}, {}, { page, limit, search });
 
-      // Mock Product.countDocuments to return count
-      Product.countDocuments = jest.fn().mockResolvedValue(3);
-
-      // Mock Product.find with chained methods
-      Product.find = jest.fn().mockReturnValue({
-        skip: jest.fn().mockReturnThis(),
-        limit: jest.fn().mockReturnThis(),
-        sort: jest.fn().mockResolvedValue(mockProductsList)
-      });
+      // Mock database calls
+      mockCountDocuments(Product, 3);
+      mockFind(Product, mockProductsList);
 
       // Execute the controller
       await productController.getProducts(req, res);
@@ -290,15 +291,8 @@ describe('Product Controller', () => {
       const limit = 10;
       req = mockRequest({}, {}, {}, { page, limit });
 
-      // Mock Product.countDocuments to return count
-      Product.countDocuments = jest.fn().mockResolvedValue(3);
-
-      // Mock Product.find with chained methods
-      Product.find = jest.fn().mockReturnValue({
-        skip: jest.fn().mockReturnThis(),
-        limit: jest.fn().mockReturnThis(),
-        sort: jest.fn().mockResolvedValue(mockProductsList)
-      });
+      mockCountDocuments(Product, 3);
+      mockFind(Product, mockProductsList);
 
       // Execute the controller
       await productController.getProducts(req, res);
@@ -338,8 +332,8 @@ describe('Product Controller', () => {
       // Mock request with product ID
       req = mockRequest({}, {}, { id: mockProduct._id.toString() });
 
-      // Mock Product.findById to return a product
-      Product.findById = jest.fn().mockResolvedValue(mockProduct);
+      // Mock Product.findById
+      mockFindById(Product, mockProduct);
 
       // Execute the controller
       await productController.getProductById(req, res);
@@ -353,8 +347,7 @@ describe('Product Controller', () => {
       // Mock request with non-existent product ID
       req = mockRequest({}, {}, { id: 'nonexistent-id' });
 
-      // Mock Product.findById to return null
-      Product.findById = jest.fn().mockResolvedValue(null);
+      mockFindById(Product, null);
 
       // Execute the controller
       await productController.getProductById(req, res);

--- a/tests/unit/controllers/purchaseController.test.js
+++ b/tests/unit/controllers/purchaseController.test.js
@@ -1,8 +1,15 @@
 // Imports
+// Uses mocks helpers from tests/mocks/mockUtils
 const mongoose = require('mongoose');
 const purchaseController = require('../../../controllers/purchaseController');
 const Purchase = require('../../../models/Purchase');
 const Product = require('../../../models/Product');
+const {
+  mockFind,
+  mockFindById,
+  mockCountDocuments,
+  mockSave
+} = require('../../mocks/mockUtils');
 const { MESSAGES } = require('../../../config/messages');
 const { 
   mockPurchase, 
@@ -27,17 +34,8 @@ describe('Purchase Controller', () => {
       const search = 'supplier';
       req = mockRequest({}, {}, {}, { page, limit, search });
 
-      // Mock Purchase.countDocuments to return count
-      Purchase.countDocuments = jest.fn().mockResolvedValue(2);
-
-      // Mock Purchase.find with chained methods
-      Purchase.find = jest.fn().mockReturnValue({
-        populate: jest.fn().mockReturnThis(),
-        populate: jest.fn().mockReturnThis(),
-        skip: jest.fn().mockReturnThis(),
-        limit: jest.fn().mockReturnThis(),
-        sort: jest.fn().mockResolvedValue(mockPurchasesList)
-      });
+      mockCountDocuments(Purchase, 2);
+      mockFind(Purchase, mockPurchasesList);
 
       // Execute the controller
       await purchaseController.getPurchases(req, res);
@@ -74,17 +72,8 @@ describe('Purchase Controller', () => {
       const limit = 10;
       req = mockRequest({}, {}, {}, { page, limit });
 
-      // Mock Purchase.countDocuments to return count
-      Purchase.countDocuments = jest.fn().mockResolvedValue(2);
-
-      // Mock Purchase.find with chained methods
-      Purchase.find = jest.fn().mockReturnValue({
-        populate: jest.fn().mockReturnThis(),
-        populate: jest.fn().mockReturnThis(),
-        skip: jest.fn().mockReturnThis(),
-        limit: jest.fn().mockReturnThis(),
-        sort: jest.fn().mockResolvedValue(mockPurchasesList)
-      });
+      mockCountDocuments(Purchase, 2);
+      mockFind(Purchase, mockPurchasesList);
 
       // Execute the controller
       await purchaseController.getPurchases(req, res);
@@ -124,13 +113,7 @@ describe('Purchase Controller', () => {
       // Mock request with purchase ID
       req = mockRequest({}, {}, { id: mockPurchase._id.toString() });
 
-      // Mock Purchase.findById with chained populate
-      const populateMock = jest.fn().mockReturnValue({
-        populate: jest.fn().mockResolvedValue(mockPurchaseWithPopulatedProducts)
-      });
-      Purchase.findById = jest.fn().mockReturnValue({
-        populate: populateMock
-      });
+      mockFindById(Purchase, mockPurchaseWithPopulatedProducts);
 
       // Execute the controller
       await purchaseController.getPurchaseById(req, res);
@@ -144,13 +127,7 @@ describe('Purchase Controller', () => {
       // Mock request with non-existent purchase ID
       req = mockRequest({}, {}, { id: 'nonexistent-id' });
 
-      // Mock Purchase.findById to return null
-      const populateMock = jest.fn().mockReturnValue({
-        populate: jest.fn().mockResolvedValue(null)
-      });
-      Purchase.findById = jest.fn().mockReturnValue({
-        populate: populateMock
-      });
+      mockFindById(Purchase, null);
 
       // Execute the controller
       await purchaseController.getPurchaseById(req, res);
@@ -222,10 +199,7 @@ describe('Purchase Controller', () => {
         updatedAt: new Date()
       };
 
-      const mockPurchaseInstance = {
-        save: jest.fn().mockResolvedValue(savedPurchase)
-      };
-      Purchase.mockImplementation(() => mockPurchaseInstance);
+      const mockPurchaseInstance = mockSave(Purchase, savedPurchase);
 
       // Execute the controller
       await purchaseController.createPurchase(req, res);
@@ -375,20 +349,11 @@ describe('Purchase Controller', () => {
       // Mock request
       req = mockRequest(updateData, {}, { id: mockPurchase._id.toString() });
 
-      // Mock Purchase.findById to return a purchase
-      Purchase.findById = jest.fn().mockResolvedValue({
+      mockFindById(Purchase, {
         ...mockPurchase,
         items: [
-          {
-            product: mockProduct._id,
-            quantity: 10,
-            purchasePrice: 50
-          },
-          {
-            product: mockProductWithVariants._id,
-            quantity: 5,
-            purchasePrice: 80
-          }
+          { product: mockProduct._id, quantity: 10, purchasePrice: 50 },
+          { product: mockProductWithVariants._id, quantity: 5, purchasePrice: 80 }
         ],
         save: jest.fn().mockResolvedValue({
           ...mockPurchase,
@@ -455,7 +420,7 @@ describe('Purchase Controller', () => {
           notes: updateData.notes
         })
       };
-      Purchase.findById = jest.fn().mockResolvedValue(purchaseToUpdate);
+      mockFindById(Purchase, purchaseToUpdate);
 
       // Execute the controller
       await purchaseController.updatePurchase(req, res);
@@ -483,8 +448,7 @@ describe('Purchase Controller', () => {
       // Mock request
       req = mockRequest(updateData, {}, { id: 'nonexistent-id' });
 
-      // Mock Purchase.findById to return null
-      Purchase.findById = jest.fn().mockResolvedValue(null);
+      mockFindById(Purchase, null);
 
       // Execute the controller
       await purchaseController.updatePurchase(req, res);

--- a/tests/unit/controllers/receiptController.test.js
+++ b/tests/unit/controllers/receiptController.test.js
@@ -1,8 +1,15 @@
 // Imports
+// Common Mongoose mocking helpers are used
 const mongoose = require('mongoose');
 const receiptController = require('../../../controllers/receiptController');
 const Receipt = require('../../../models/Receipt');
 const Sale = require('../../../models/Sale');
+const {
+  mockFind,
+  mockFindById,
+  mockCountDocuments,
+  mockSave
+} = require('../../mocks/mockUtils');
 const generateReceipt = require('../../../utils/receiptGenerator');
 const { mockReceipt, mockReceiptWithPopulatedSale } = require('../../mocks/receiptMock');
 const { mockCashSale } = require('../../mocks/saleMock');

--- a/tests/unit/controllers/statsController.test.js
+++ b/tests/unit/controllers/statsController.test.js
@@ -1,10 +1,17 @@
 // Imports
+// The tests use helper mocks from tests/mocks/mockUtils
 const mongoose = require('mongoose');
 const statsController = require('../../../controllers/statsController');
 const Sale = require('../../../models/Sale');
 const Product = require('../../../models/Product');
 const PosSession = require('../../../models/PosSession');
 const OperationalExpense = require('../../../models/OperationalExpense');
+const {
+  mockFind,
+  mockFindById,
+  mockCountDocuments,
+  mockSave
+} = require('../../mocks/mockUtils');
 const { MESSAGES } = require('../../../config/messages');
 const { 
   mockCashSale, 
@@ -33,7 +40,7 @@ jest.mock('../../../models/OperationalExpense');
 describe('Stats Controller', () => {
   beforeEach(() => {
     // THIS NEEDS TO BE ADDED AS A MOCK IN THE MOCKS FOLDER
-    OperationalExpense.find = jest.fn().mockResolvedValue([]);
+    mockFind(OperationalExpense, []);
   });
 
   describe('getSalesStats', () => {

--- a/tests/unit/controllers/userController.test.js
+++ b/tests/unit/controllers/userController.test.js
@@ -1,8 +1,15 @@
 // Imports
+// Mongoose helper mocks from tests/mocks/mockUtils
 const mongoose = require('mongoose');
 const { MESSAGES } = require('../../../config/messages');
 const userController = require('../../../controllers/userController');
 const User = require('../../../models/User');
+const {
+  mockFind,
+  mockFindById,
+  mockCountDocuments,
+  mockSave
+} = require('../../mocks/mockUtils');
 const { mockUser, mockAdmin, mockUnapprovedUser, mockUsersList } = require('../../mocks/userMock');
 
 // Mock the mongoose models
@@ -12,10 +19,7 @@ describe('User Controller', () => {
 
   describe('getUsers', () => {
     test('should get all users successfully', async () => {
-      // Mock User.find to return users
-      User.find = jest.fn().mockReturnValue({
-        select: jest.fn().mockResolvedValue(mockUsersList)
-      });
+      mockFind(User, mockUsersList);
 
       // Execute the controller
       await userController.getUsers(req, res);
@@ -48,10 +52,7 @@ describe('User Controller', () => {
       // Mock request with user ID
       req = mockRequest({}, {}, { id: mockUser._id.toString() });
 
-      // Mock User.findById to return a user
-      User.findById = jest.fn().mockReturnValue({
-        select: jest.fn().mockResolvedValue(mockUser)
-      });
+      mockFindById(User, mockUser);
 
       // Execute the controller
       await userController.getUserById(req, res);


### PR DESCRIPTION
## Summary
- extend mockUtils with helpers for common mongoose patterns
- refactor controller tests to use these helpers
- document mock usage at the top of each test file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684df60ddd34832a841e2bbf64f33b9e