### PR TITLE
Add global console.error spy in test setup

### DIFF
--- a/tests/setupTests.js
+++ b/tests/setupTests.js
@@ -7,6 +7,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   global.req = mockRequest();
   global.res = mockResponse();
+  jest.spyOn(console, 'error').mockImplementation(() => {});
 });
 
 afterEach(() => {

--- a/tests/unit/controllers/paymentMethodController.test.js
+++ b/tests/unit/controllers/paymentMethodController.test.js
@@ -22,9 +22,6 @@ const { MESSAGES } = require('../../../config/messages');
 jest.mock('../../../models/PaymentMethod');
 
 describe('Payment Method Controller', () => {
-  beforeEach(() => {
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-  });
 
   describe('getPaymentMethods', () => {
     test('should get all payment methods successfully', async () => {

--- a/tests/unit/controllers/posSessionController.test.js
+++ b/tests/unit/controllers/posSessionController.test.js
@@ -28,9 +28,6 @@ jest.mock('../../../models/PosSession');
 jest.mock('../../../models/Sale');
 
 describe('POS Session Controller', () => {
-  beforeEach(() => {
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-  });
 
   const setupMockFindOne = (returnValue) => {
     PosSession.findOne = jest.fn().mockResolvedValue(returnValue);


### PR DESCRIPTION
## Summary
- add a console.error spy in `tests/setupTests.js`
- drop individual spies from unit test files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f0176e670832a87334da0f2b2a9f7